### PR TITLE
feat: v20.3 upgrade + release cleanup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,9 +4,9 @@ before:
     - go mod download
 
 builds:
-  - id: "evmosd-darwin"
-    main: ./cmd/evmosd
-    binary: bin/evmosd
+  - id: "atoshid-darwin"
+    main: ./cmd/atoshid
+    binary: bin/atoshid
     env:
       - CGO_ENABLED=1
       - CC=o64-clang
@@ -18,10 +18,10 @@ builds:
     flags:
       - -tags=cgo
     ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=evmos -X github.com/cosmos/cosmos-sdk/version.AppName=evmosd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
-  - id: "evmosd-darwin-arm64"
-    main: ./cmd/evmosd
-    binary: bin/evmosd
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=atoshi -X github.com/cosmos/cosmos-sdk/version.AppName=atoshid -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "atoshid-darwin-arm64"
+    main: ./cmd/atoshid
+    binary: bin/atoshid
     env:
       - CGO_ENABLED=1
       - CC=oa64-clang
@@ -33,10 +33,10 @@ builds:
     flags:
       - -tags=cgo
     ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=evmos -X github.com/cosmos/cosmos-sdk/version.AppName=evmosd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
-  - id: "evmosd-linux"
-    main: ./cmd/evmosd
-    binary: bin/evmosd
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=atoshi -X github.com/cosmos/cosmos-sdk/version.AppName=atoshid -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "atoshid-linux"
+    main: ./cmd/atoshid
+    binary: bin/atoshid
     env:
       - CGO_ENABLED=1
       - CC=gcc
@@ -48,10 +48,10 @@ builds:
     flags:
       - -tags=cgo
     ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=evmos -X github.com/cosmos/cosmos-sdk/version.AppName=evmosd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
-  - id: "evmosd-linux-arm64"
-    main: ./cmd/evmosd
-    binary: bin/evmosd
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=atoshi -X github.com/cosmos/cosmos-sdk/version.AppName=atoshid -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "atoshid-linux-arm64"
+    main: ./cmd/atoshid
+    binary: bin/atoshid
     env:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc
@@ -63,10 +63,10 @@ builds:
     flags:
       - -tags=cgo
     ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=evmos -X github.com/cosmos/cosmos-sdk/version.AppName=evmosd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
-  - id: "evmosd-windows"
-    main: ./cmd/evmosd
-    binary: bin/evmosd
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=atoshi -X github.com/cosmos/cosmos-sdk/version.AppName=atoshid -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "atoshid-windows"
+    main: ./cmd/atoshid
+    binary: bin/atoshid
     env:
       - CGO_ENABLED=1
       - CC=x86_64-w64-mingw32-gcc
@@ -79,7 +79,7 @@ builds:
       - -tags=cgo
       - -buildmode=exe
     ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=evmos -X github.com/cosmos/cosmos-sdk/version.AppName=evmosd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=atoshi -X github.com/cosmos/cosmos-sdk/version.AppName=atoshid -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}"
@@ -87,11 +87,11 @@ archives:
       - goos: windows
         format: zip
     builds:
-      - evmosd-darwin
-      - evmosd-darwin-arm64
-      - evmosd-windows
-      - evmosd-linux
-      - evmosd-linux-arm64
+      - atoshid-darwin
+      - atoshid-darwin-arm64
+      - atoshid-windows
+      - atoshid-linux
+      - atoshid-linux-arm64
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ ifdef GITHUB_TOKEN
 		DOCKER_ARGS += --secret id=GITHUB_TOKEN
 	endif
 endif
-NAMESPACE := tharsishq
-PROJECT := evmos
+NAMESPACE := atoshi-chain
+PROJECT := atoshi
 DOCKER_IMAGE := $(NAMESPACE)/$(PROJECT)
 COMMIT_HASH := $(shell git rev-parse --short=7 HEAD)
 DOCKER_TAG := $(COMMIT_HASH)
@@ -75,7 +75,7 @@ build_tags := $(strip $(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=evmos \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=atoshi \
           -X github.com/cosmos/cosmos-sdk/version.AppName=$(EVMOS_BINARY) \
           -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
           -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
@@ -533,7 +533,7 @@ proto-download-deps:
 ###                                Releasing                                ###
 ###############################################################################
 
-PACKAGE_NAME:=github.com/evmos/evmos
+PACKAGE_NAME:=github.com/atoshi-chain/atoshi/v20
 GOLANG_CROSS_VERSION  = v1.22
 GOPATH ?= '$(HOME)/go'
 release-dry-run:

--- a/app/app.go
+++ b/app/app.go
@@ -144,6 +144,7 @@ import (
 	v20 "github.com/atoshi-chain/atoshi/v20/app/upgrades/v20"
 	v20_1 "github.com/atoshi-chain/atoshi/v20/app/upgrades/v20_1"
 	v20_2 "github.com/atoshi-chain/atoshi/v20/app/upgrades/v20_2"
+	v20_3 "github.com/atoshi-chain/atoshi/v20/app/upgrades/v20_3"
 	srvflags "github.com/atoshi-chain/atoshi/v20/server/flags"
 	"github.com/atoshi-chain/atoshi/v20/x/erc20"
 	erc20keeper "github.com/atoshi-chain/atoshi/v20/x/erc20/keeper"
@@ -1332,6 +1333,18 @@ func (app *Atoshi) setupUpgradeHandlers() {
 		v20_2.CreateUpgradeHandler(
 			app.mm, app.configurator,
 			app.InflationKeeper,
+		),
+	)
+
+	// v20.3: adds two governance-tunable delegation-duration params
+	// (default + max hard cap). Handler sets both to 86400 (24h) on
+	// live chains so state has explicit values rather than relying on
+	// the msg_server compiled-constant fallback.
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v20_3.UpgradeName,
+		v20_3.CreateUpgradeHandler(
+			app.mm, app.configurator,
+			app.EnergyKeeper,
 		),
 	)
 

--- a/app/upgrades/v20_3/constants.go
+++ b/app/upgrades/v20_3/constants.go
@@ -1,0 +1,18 @@
+package v20_3
+
+// UpgradeName is the on-chain plan name for the v20.3 upgrade.
+//
+// v20.3 introduces two governance-tunable delegation-duration params:
+//
+//   - default_delegation_duration_seconds (field 11): substitute value
+//     when MsgDelegateEnergy is submitted with duration_seconds == 0.
+//   - max_delegation_duration_seconds   (field 12): hard cap; msgs
+//     exceeding this value are rejected.
+//
+// Handler action: set both params to 86400 (24h) explicitly on live
+// chains. The msg_server fallback also picks up the compiled 24h
+// constant when the field is zero (pre-upgrade state compat), so the
+// upgrade could technically be a no-op — but writing the values into
+// on-chain state makes the intent explicit and removes any reliance
+// on the code-side fallback going forward.
+const UpgradeName = "v20.3"

--- a/app/upgrades/v20_3/upgrades.go
+++ b/app/upgrades/v20_3/upgrades.go
@@ -1,0 +1,44 @@
+package v20_3
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	energykeeper "github.com/atoshi-chain/atoshi/v20/x/energy/keeper"
+)
+
+// CreateUpgradeHandler returns the v20.3 upgrade handler.
+//
+// Sets the two new energy params (default/max delegation duration) to
+// 86400 (24h) so post-upgrade state has explicit values rather than
+// relying on the compiled-constant fallback in msg_server.
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	ek energykeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		newVM, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return newVM, err
+		}
+
+		params := ek.GetParams(ctx)
+		params.DefaultDelegationDurationSeconds = 86_400 // 24h
+		params.MaxDelegationDurationSeconds = 86_400     // 24h hard cap
+		if err := ek.SetParams(ctx, params); err != nil {
+			return newVM, err
+		}
+		logger.Info("set delegation duration params",
+			"default", params.DefaultDelegationDurationSeconds,
+			"max", params.MaxDelegationDurationSeconds)
+
+		return newVM, nil
+	}
+}

--- a/proto/atoshi/energy/v1/energy.proto
+++ b/proto/atoshi/energy/v1/energy.proto
@@ -66,6 +66,17 @@ message Params {
   // delegations to non-whitelisted addresses are still allowed but do not
   // automatically map to L2 quota.
   repeated string privacy_relayer_whitelist = 10;
+
+  // default_delegation_duration_seconds is applied when MsgDelegateEnergy
+  // omits duration (protobuf zero). Zero here falls back to the compiled
+  // constant so pre-upgrade Params state (which lacks this field) still
+  // works without genesis migration.
+  int64 default_delegation_duration_seconds = 11;
+
+  // max_delegation_duration_seconds is a hard cap. Msgs with
+  // duration_seconds > this value are rejected. Zero here means "no cap
+  // enforced" (pre-upgrade state compat).
+  int64 max_delegation_duration_seconds = 12;
 }
 
 // EnergyAccount tracks a single account's accrued energy and delegation

--- a/x/energy/keeper/msg_server.go
+++ b/x/energy/keeper/msg_server.go
@@ -24,15 +24,26 @@ func (s msgServer) DelegateEnergy(goCtx context.Context, msg *types.MsgDelegateE
 		return nil, err
 	}
 
-	// Apply the protocol default when the client did not specify a
-	// duration. Protobuf int64 zero-value is the natural "field not
-	// set" signal — wallets that don't expose a duration picker can
-	// simply omit the field. ValidateBasic above accepts 0 and
-	// rejects negatives; the keeper's Delegate still requires > 0,
-	// so any 0 reaching it would error — we normalize here once.
+	// Duration policy:
+	//   1. Client-supplied 0 → substitute the protocol default (prefer
+	//      the governance-set params value; fall back to the compiled
+	//      constant so pre-upgrade state without this field still works).
+	//   2. Enforce the governance-set max cap (skip when unset / 0,
+	//      meaning "no cap" for backward compat with pre-upgrade state).
+	params := s.GetParams(ctx)
 	duration := msg.DurationSeconds
 	if duration == 0 {
-		duration = types.DefaultDelegationDurationSeconds
+		if params.DefaultDelegationDurationSeconds > 0 {
+			duration = params.DefaultDelegationDurationSeconds
+		} else {
+			duration = types.DefaultDelegationDurationSeconds
+		}
+	}
+	if params.MaxDelegationDurationSeconds > 0 &&
+		duration > params.MaxDelegationDurationSeconds {
+		return nil, fmt.Errorf(
+			"duration_seconds %d exceeds max_delegation_duration_seconds %d",
+			duration, params.MaxDelegationDurationSeconds)
 	}
 
 	id, locked, err := s.Delegate(ctx, delegator, delegatee, msg.Amount, duration)

--- a/x/energy/keeper/msg_server_test.go
+++ b/x/energy/keeper/msg_server_test.go
@@ -47,9 +47,9 @@ func TestMsgDelegateEnergy_ZeroDurationUsesProtocolDefault(t *testing.T) {
 	startTime := ctx.BlockTime().Unix()
 	want := startTime + types.DefaultDelegationDurationSeconds
 	require.Equal(t, want, d.ExpiresAt,
-		"DurationSeconds=0 must be normalized to DefaultDelegationDurationSeconds (7 days)")
-	require.EqualValues(t, 604_800, types.DefaultDelegationDurationSeconds,
-		"7 days in seconds")
+		"DurationSeconds=0 must be normalized to the params default (24h)")
+	require.EqualValues(t, 86_400, types.DefaultDelegationDurationSeconds,
+		"24h in seconds")
 }
 
 // Sanity: an explicitly-set duration is honored verbatim. The default
@@ -71,7 +71,7 @@ func TestMsgDelegateEnergy_ExplicitDurationHonored(t *testing.T) {
 	a.TxEnergyAccrued = 150_000
 	k.SetEnergyAccount(ctx, a)
 
-	const explicit int64 = 3 * 24 * 60 * 60 // 3 days
+	const explicit int64 = 12 * 60 * 60 // 12 hours, within the 24h cap
 	resp, err := srv.DelegateEnergy(ctx, &types.MsgDelegateEnergy{
 		Delegator:       delegator.String(),
 		Delegatee:       delegatee.String(),
@@ -83,6 +83,61 @@ func TestMsgDelegateEnergy_ExplicitDurationHonored(t *testing.T) {
 	d, ok := k.GetDelegation(ctx, resp.DelegationId)
 	require.True(t, ok)
 	require.Equal(t, ctx.BlockTime().Unix()+explicit, d.ExpiresAt)
+}
+
+// Duration > MaxDelegationDurationSeconds must be rejected.
+func TestMsgDelegateEnergy_DurationExceedsMaxRejected(t *testing.T) {
+	k, ctx, bank := newKeeperForTest(t)
+	srv := NewMsgServerImpl(k)
+
+	delegator := addr("delegator_______________")
+	delegatee := addr("delegatee_______________")
+
+	bank.balances[delegator.String()] = math.NewIntWithDecimal(90_000, 18)
+	bank.balances[delegatee.String()] = math.NewIntWithDecimal(60_000, 18)
+	bank.onSend = func(from, to sdk.AccAddress, amt sdk.Coins) {
+		_, _ = k.SendRestriction(ctx, from, to, amt)
+	}
+	a := k.Settle(ctx, delegator)
+	a.TxEnergyAccrued = 150_000
+	k.SetEnergyAccount(ctx, a)
+
+	// Default params: Max = 86400 (24h). 24h + 1s must be rejected.
+	_, err := srv.DelegateEnergy(ctx, &types.MsgDelegateEnergy{
+		Delegator:       delegator.String(),
+		Delegatee:       delegatee.String(),
+		Amount:          50_000,
+		DurationSeconds: 86_400 + 1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max_delegation_duration_seconds")
+}
+
+// Duration exactly equal to Max is accepted (boundary).
+func TestMsgDelegateEnergy_DurationEqualsMaxAccepted(t *testing.T) {
+	k, ctx, bank := newKeeperForTest(t)
+	srv := NewMsgServerImpl(k)
+
+	delegator := addr("delegator_______________")
+	delegatee := addr("delegatee_______________")
+
+	bank.balances[delegator.String()] = math.NewIntWithDecimal(90_000, 18)
+	bank.balances[delegatee.String()] = math.NewIntWithDecimal(60_000, 18)
+	bank.onSend = func(from, to sdk.AccAddress, amt sdk.Coins) {
+		_, _ = k.SendRestriction(ctx, from, to, amt)
+	}
+	a := k.Settle(ctx, delegator)
+	a.TxEnergyAccrued = 150_000
+	k.SetEnergyAccount(ctx, a)
+
+	resp, err := srv.DelegateEnergy(ctx, &types.MsgDelegateEnergy{
+		Delegator:       delegator.String(),
+		Delegatee:       delegatee.String(),
+		Amount:          50_000,
+		DurationSeconds: 86_400, // exactly at the cap
+	})
+	require.NoError(t, err)
+	require.NotZero(t, resp.DelegationId)
 }
 
 // ValidateBasic: 0 must be ACCEPTED (means "use default"); negative

--- a/x/energy/types/energy.pb.go
+++ b/x/energy/types/energy.pb.go
@@ -64,6 +64,12 @@ type Params struct {
 	// delegations to non-whitelisted addresses are still allowed but do not
 	// automatically map to L2 quota.
 	PrivacyRelayerWhitelist []string `protobuf:"bytes,10,rep,name=privacy_relayer_whitelist,json=privacyRelayerWhitelist,proto3" json:"privacy_relayer_whitelist,omitempty"`
+	// default_delegation_duration_seconds is applied when MsgDelegateEnergy
+	// omits duration. Zero here falls back to compiled constant.
+	DefaultDelegationDurationSeconds int64 `protobuf:"varint,11,opt,name=default_delegation_duration_seconds,json=defaultDelegationDurationSeconds,proto3" json:"default_delegation_duration_seconds,omitempty"`
+	// max_delegation_duration_seconds is a hard cap on delegation duration.
+	// Msgs with duration_seconds > this are rejected. Zero means no cap.
+	MaxDelegationDurationSeconds int64 `protobuf:"varint,12,opt,name=max_delegation_duration_seconds,json=maxDelegationDurationSeconds,proto3" json:"max_delegation_duration_seconds,omitempty"`
 }
 
 func (m *Params) Reset()         { *m = Params{} }
@@ -146,6 +152,20 @@ func (m *Params) GetPrivacyRelayerWhitelist() []string {
 		return m.PrivacyRelayerWhitelist
 	}
 	return nil
+}
+
+func (m *Params) GetDefaultDelegationDurationSeconds() int64 {
+	if m != nil {
+		return m.DefaultDelegationDurationSeconds
+	}
+	return 0
+}
+
+func (m *Params) GetMaxDelegationDurationSeconds() int64 {
+	if m != nil {
+		return m.MaxDelegationDurationSeconds
+	}
+	return 0
 }
 
 // EnergyAccount tracks a single account's accrued energy and delegation
@@ -430,6 +450,16 @@ func (m *Params) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.MaxDelegationDurationSeconds != 0 {
+		i = encodeVarintEnergy(dAtA, i, uint64(m.MaxDelegationDurationSeconds))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.DefaultDelegationDurationSeconds != 0 {
+		i = encodeVarintEnergy(dAtA, i, uint64(m.DefaultDelegationDurationSeconds))
+		i--
+		dAtA[i] = 0x58
+	}
 	if len(m.PrivacyRelayerWhitelist) > 0 {
 		for iNdEx := len(m.PrivacyRelayerWhitelist) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.PrivacyRelayerWhitelist[iNdEx])
@@ -707,6 +737,12 @@ func (m *Params) Size() (n int) {
 			l = len(s)
 			n += 1 + l + sovEnergy(uint64(l))
 		}
+	}
+	if m.DefaultDelegationDurationSeconds != 0 {
+		n += 1 + sovEnergy(uint64(m.DefaultDelegationDurationSeconds))
+	}
+	if m.MaxDelegationDurationSeconds != 0 {
+		n += 1 + sovEnergy(uint64(m.MaxDelegationDurationSeconds))
 	}
 	return n
 }
@@ -1074,6 +1110,44 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 			}
 			m.PrivacyRelayerWhitelist = append(m.PrivacyRelayerWhitelist, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DefaultDelegationDurationSeconds", wireType)
+			}
+			m.DefaultDelegationDurationSeconds = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEnergy
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DefaultDelegationDurationSeconds |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxDelegationDurationSeconds", wireType)
+			}
+			m.MaxDelegationDurationSeconds = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEnergy
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxDelegationDurationSeconds |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipEnergy(dAtA[iNdEx:])

--- a/x/energy/types/helpers.go
+++ b/x/energy/types/helpers.go
@@ -39,7 +39,9 @@ func DefaultParams() Params {
 			"/atoshi.energy.v1.MsgDelegateEnergy",
 			"/atoshi.energy.v1.MsgUndelegateEnergy",
 		},
-		PrivacyRelayerWhitelist: []string{},
+		PrivacyRelayerWhitelist:          []string{},
+		DefaultDelegationDurationSeconds: 86_400, // 24h
+		MaxDelegationDurationSeconds:     86_400, // 24h, hard cap
 	}
 }
 
@@ -70,6 +72,22 @@ func (p Params) Validate() error {
 		if _, err := sdk.AccAddressFromBech32(addr); err != nil {
 			return fmt.Errorf("invalid privacy relayer address %q: %w", addr, err)
 		}
+	}
+	// Delegation-duration params: 0 means "not set in state" and code
+	// falls back to compiled defaults. When both are set, default must
+	// not exceed max, otherwise a client omitting duration would be
+	// auto-rejected against the cap.
+	if p.DefaultDelegationDurationSeconds < 0 {
+		return fmt.Errorf("default_delegation_duration_seconds cannot be negative")
+	}
+	if p.MaxDelegationDurationSeconds < 0 {
+		return fmt.Errorf("max_delegation_duration_seconds cannot be negative")
+	}
+	if p.MaxDelegationDurationSeconds > 0 &&
+		p.DefaultDelegationDurationSeconds > p.MaxDelegationDurationSeconds {
+		return fmt.Errorf(
+			"default_delegation_duration_seconds (%d) exceeds max_delegation_duration_seconds (%d)",
+			p.DefaultDelegationDurationSeconds, p.MaxDelegationDurationSeconds)
 	}
 	return nil
 }

--- a/x/energy/types/keys.go
+++ b/x/energy/types/keys.go
@@ -14,15 +14,12 @@ const (
 	// and back to the delegator's bank account on Undelegate / expire.
 	LockedEnergyPoolName = "energy_locked_pool"
 
-	// DefaultDelegationDurationSeconds is the duration applied by the
-	// MsgDelegateEnergy server when a client submits the message with
-	// duration_seconds == 0 (the protobuf zero value, i.e. "field not
-	// set"). Seven days is short enough for delegators to recover
-	// stake quickly if they change their mind, but long enough for
-	// dApps subsidizing user gas to keep delegating in batches
-	// rather than per-tx. Wallets can choose to expose a duration
-	// picker — sending 0 means "use this default".
-	DefaultDelegationDurationSeconds int64 = 7 * 24 * 60 * 60 // 7 days = 604800 s
+	// DefaultDelegationDurationSeconds is the compiled fallback used by
+	// the MsgDelegateEnergy server ONLY when Params.DefaultDelegationDurationSeconds
+	// is zero (i.e. pre-upgrade state that predates that field). Under
+	// normal operation the governance-set params value is preferred.
+	// Kept aligned with the DefaultParams() value for consistency.
+	DefaultDelegationDurationSeconds int64 = 24 * 60 * 60 // 24h = 86400 s
 )
 
 const (


### PR DESCRIPTION
Merges `fix/audit-round-3` → `main`. This batch bundles the v20.3 chain 
upgrade (governance-tunable delegation duration + hard cap) and the 
`.goreleaser.yml` rebrand.

## v20.3 chain upgrade

Adds two new energy `Params` fields (governance-mutable via 
`MsgUpdateParams`):

| field | value | effect |
|---|---|---|
| `default_delegation_duration_seconds` | `86400` (24h) | Substituted when `MsgDelegateEnergy` omits `duration_seconds` |
| `max_delegation_duration_seconds` | `86400` (24h) | Hard cap; msgs with `duration_seconds > 86400` are rejected |

Previously the delegation default was a compiled 7-day constant with 
no cap. Governance can now retune either value without a code change.

Upgrade handler (`app/upgrades/v20_3`) atomically populates both 
fields to `86400` on live chains, so post-upgrade state has explicit 
values rather than relying on the `msg_server` compiled-constant 
fallback.

**Compatibility**: fields are proto3 tail-added (11, 12). Pre-upgrade 
`Params` state reads with both fields = 0; msg_server has a fallback 
path so behavior stays defined even before the upgrade handler runs. 
Serialized state bytes are identical when the new fields are zero — 
no AppHash divergence risk during the halt-height window.

Related commits:
- `6783800` feat(energy): governance-tunable delegation duration default + hard cap
- `57cdde0` feat(upgrades): register v20.3 upgrade handler

## `.goreleaser.yml` rebrand

The file was an untouched evmos fork remnant — 5 build blocks all 
referenced `./cmd/evmosd` (which does not exist; the actual command 
is `./cmd/atoshid`), produced binaries named `evmosd`, and ldflags 
set `version.Name=evmos` / `version.AppName=evmosd`. Running 
`goreleaser build` on the previous config would fail or ship a 
mislabeled artifact.

Mechanical rename only. See the commit for the full diff.

Related commit:
- `<新 hash>` chore(release): rebrand .goreleaser.yml from evmos → atoshi

## Testing

- [x] `go build ./...` clean
- [x] `go test ./x/energy/... ./x/oracle/... ./x/tokenomics/...` all green
  - New tests: `TestMsgDelegateEnergy_DurationExceedsMaxRejected`, 
    `TestMsgDelegateEnergy_DurationEqualsMaxAccepted`
  - Updated: `TestMsgDelegateEnergy_ExplicitDurationHonored` (12h instead of 3d)
- [x] Cross-checked `v20.3` UpgradeName consistency: 
      `app/upgrades/v20_3/constants.go` = `app.go` SetUpgradeHandler = 
      proposal JSON `plan.name`
- [ ] Testnet v20.3 upgrade rehearsal (pending)
- [ ] Mainnet v20.3 upgrade (pending; requires halt-height coordination)

## Operational notes

- Upgrade governance proposal: `docs/proposal-v20_3-software-upgrade.json`
- MsgUpdateParams proposal (if params need retuning without a code 
  release): `docs/proposal-set-delegation-duration-caps.json`
- All 11 nodes (7 validators + 2 RPC + archive + browser) must have 
  the new binary installed before the halt height submitted in the 
  gov proposal.

## Reviewer checklist

- [ ] Merge with `--no-ff` to preserve audit-branch history
- [ ] After merge, tag `v20.3.0`
- [ ] Run testnet upgrade dry-run before submitting the mainnet 
      gov proposal
